### PR TITLE
Forces UTF-8 encoding on both JSON and JSONP responses

### DIFF
--- a/lib/sinatra/jsonp.rb
+++ b/lib/sinatra/jsonp.rb
@@ -15,10 +15,10 @@ module Sinatra
         end
         if callback
           callback.tr!('^a-zA-Z0-9_$\.', '')
-          content_type :js
+          content_type :js, charset: 'utf-8'
           response = "#{callback}(#{data})"
         else
-          content_type :json
+          content_type :json, charset: 'utf-8'
           response = data
         end
         response

--- a/spec/jsonp_spec.rb
+++ b/spec/jsonp_spec.rb
@@ -6,6 +6,10 @@ describe Sinatra::Jsonp do
     mock_app do
       helpers Sinatra::Jsonp
 
+      before do
+        content_type 'application/json', 'charset' => 'utf-8'
+      end
+
       get '/method' do
         data = ["hello","hi","hallo"]
         jsonp data
@@ -21,9 +25,20 @@ describe Sinatra::Jsonp do
     get '/method'
     body.should == '["hello","hi","hallo"]'
   end
+
+  it "returns UTF-8 as charset for JSON responses" do
+    get '/method'
+    last_response.headers['Content-Type'].downcase.should =~ /charset=utf-8/
+  end
+
   it "returns JSONP if callback passed via request params" do
     get '/method?callback=functionA'
     body.should == 'functionA(["hello","hi","hallo"])'
+  end
+
+  it "returns UTF-8 as charset for JSONP responses" do
+    get '/method?callback=functionA'
+    last_response.headers['Content-Type'].downcase.should  =~ /charset=utf-8/
   end
 
   it "returns JSONP with sanitized callback" do


### PR DESCRIPTION
This explicitly sets the charset of the response to UTF-8 what is the root issue in: [#3790](https://github.com/easybib/issues/issues/3790)

Using this fix the CSL app is correctly returning UTF-8 encoded JSON and JSONP.

/cc @fh @darshanbib @rwos Someone please merge!